### PR TITLE
datetimepicker with v-model

### DIFF
--- a/src/components/Datetimepicker.vue
+++ b/src/components/Datetimepicker.vue
@@ -1,7 +1,7 @@
 
 <template>
     <div class="input-group">
-        <input type="text" :id="'date_time_' + id" class="form-control" autocomplete="off" :disabled="disabled" :name="name" :required="required">
+        <input type="text" @input="onInput" :id="'date_time_' + id" class="form-control" autocomplete="off" :disabled="disabled" :name="name" :required="required">
         <div class="input-group-addon cursor-pointer"><i :class="options.icons.date"></i>
         </div>
     </div>
@@ -26,6 +26,11 @@ export default {
   },
   destroyed: function () {
     this.destroyDatetimepicker()
+  },
+  methods: {
+    onInput (event) {
+      this.$emit('input', event.srcElement.value)
+    }
   }
 }
 </script>


### PR DESCRIPTION
With this pull request the v-model can be used on the datetimepicker component - `<datetimepicker v-model="the_date">`